### PR TITLE
fix: caching for unreal parser

### DIFF
--- a/src/Wbtb.Extensions.LogParsing.Unreal/Unreal4.cs
+++ b/src/Wbtb.Extensions.LogParsing.Unreal/Unreal4.cs
@@ -67,7 +67,7 @@ namespace Wbtb.Extensions.LogParsing.Unreal
             // try for cache
             Cache cache = di.Resolve<Cache>();
             CachePayload shaderMatchLookup = cache.Get(this, job, build, this.ContextPluginConfig.Key);
-            if (shaderMatchLookup != null)
+            if (shaderMatchLookup.Payload != null)
                 return shaderMatchLookup.Payload;
 
             StringBuilder allMatches = new StringBuilder();


### PR DESCRIPTION
cache.Get() always returns an object, so it would always return and never run the unreal parser